### PR TITLE
[Security] Add Express JSON payload size limits

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -75,8 +75,8 @@ app.use(requestLogger);
 app.use('/api/', apiLimiter);
 
 // Enable JSON parsing for incoming requests
-app.use(express.json());
-
+app.use(express.json({ limit: '10kb' }))
+app.use(express.urlencoded({ extended: true, limit: '10kb' }))
 // Enable CORS (Cross-Origin Resource Sharing)
 // Restrict to specific frontend origin for security
 const allowedOrigins = [


### PR DESCRIPTION
Closes #19

## Changes
- Added 10kb limit to express.json()
- Added 10kb limit to express.urlencoded()
- Returns 413 automatically on oversized payloads

## Impact
- Prevents memory pressure from large payloads
- Mitigates DOS attack vector