### PR TITLE
Fix: Enforce request schema on Gmail fetch route (Resolves #18)

### DIFF
--- a/backend/middleware/validation.js
+++ b/backend/middleware/validation.js
@@ -56,6 +56,10 @@ const gmailFetchSchema = z.object({
   maxResults: z.coerce.number().int().positive().max(500).optional(),
   pageToken: z.string().optional(),
   query: z.string().max(200).optional(),
+  dateFrom: z.union([z.string().datetime(), z.literal('')]).optional().transform(val => val === '' ? undefined : val),
+  dateTo: z.union([z.string().datetime(), z.literal('')]).optional().transform(val => val === '' ? undefined : val),
+  fetchAll: z.boolean().optional(),
+  timeRange: z.enum(['5m', '15m', '30m', '1h', '6h', '12h', '1d', '3d', '7d', '30d', 'all']).optional(),
 });
 
 // Route parameter validation for ObjectId
@@ -96,7 +100,7 @@ const validate = (schema, source = 'body') => {
         return res.status(400).json({
           success: false,
           message: 'Invalid request data',
-          errors: error.errors?.map(err => ({
+          errors: (error.errors || error.issues)?.map(err => ({
             field: err.path.join('.'),
             message: err.message,
           })) || [],

--- a/backend/routes/gmailRoutes.js
+++ b/backend/routes/gmailRoutes.js
@@ -74,9 +74,9 @@ router.delete('/disconnect', timeout('30s'), authMiddleware, syncUserMiddleware,
 router.post('/fetch', 
   timeout('180s'), // 3 minute timeout for Gmail fetch (handles large email volumes)
   gmailFetchLimiter, 
+  validate(schemas.gmailFetch, 'body'), 
   authMiddleware, 
   syncUserMiddleware, 
-  validate(schemas.gmailFetch, 'query'), 
   invalidateCacheMiddleware(), // Invalidate user cache after fetch
   fetchAndSaveEmails
 );

--- a/backend/test-gmail-validation.js
+++ b/backend/test-gmail-validation.js
@@ -1,0 +1,90 @@
+const { validate, schemas } = require('./middleware/validation');
+
+const assert = (condition, message) => {
+  if (!condition) {
+    console.error(`❌ Assertion failed: ${message}`);
+    process.exit(1);
+  }
+};
+
+const runTests = () => {
+  console.log('Running invalid-input tests for Gmail fetch route validation...');
+  
+  const middleware = validate(schemas.gmailFetch, 'body');
+  
+  // Helper to create mock req/res
+  const createMocks = (body) => {
+    const req = { body };
+    const res = {
+      statusCode: null,
+      data: null,
+      status: function(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json: function(data) {
+        this.data = data;
+        return this;
+      }
+    };
+    let nextCalled = false;
+    const next = () => { nextCalled = true; };
+    return { req, res, next, getNextCalled: () => nextCalled };
+  };
+
+  // Test case 1: Invalid maxResults (too large)
+  const { req: req1, res: res1, next: next1, getNextCalled: next1Called } = createMocks({ maxResults: 1000 });
+  middleware(req1, res1, next1);
+  
+  assert(!next1Called(), 'Next should not be called for invalid maxResults');
+  assert(res1.statusCode === 400, 'Status code should be 400 for invalid maxResults');
+  assert(res1.data && res1.data.success === false, 'Response success should be false');
+  assert(res1.data.errors.some(e => e.field === 'maxResults'), 'Should have error for maxResults');
+  console.log('✔️  Caught invalid maxResults (> 500)');
+  
+  // Test case 2: Invalid maxResults (negative)
+  const { req: req2, res: res2, next: next2, getNextCalled: next2Called } = createMocks({ maxResults: -10 });
+  middleware(req2, res2, next2);
+  
+  assert(!next2Called(), 'Next should not be called for negative maxResults');
+  assert(res2.statusCode === 400, 'Status code should be 400 for negative maxResults');
+  assert(res2.data.errors.some(e => e.field === 'maxResults'), 'Should have error for maxResults');
+  console.log('✔️  Caught invalid maxResults (< 1)');
+
+  // Test case 3: Invalid timeRange
+  const { req: req3, res: res3, next: next3, getNextCalled: next3Called } = createMocks({ timeRange: 'invalid_time' });
+  middleware(req3, res3, next3);
+  
+  assert(!next3Called(), 'Next should not be called for invalid timeRange');
+  assert(res3.statusCode === 400, 'Status code should be 400 for invalid timeRange');
+  assert(res3.data.errors.some(e => e.field === 'timeRange'), 'Should have error for timeRange');
+  console.log('✔️  Caught invalid timeRange');
+
+  // Test case 4: Invalid date format
+  const { req: req4, res: res4, next: next4, getNextCalled: next4Called } = createMocks({ dateFrom: 'not-a-date' });
+  middleware(req4, res4, next4);
+  
+  assert(!next4Called(), 'Next should not be called for invalid date format');
+  assert(res4.statusCode === 400, 'Status code should be 400 for invalid date format');
+  assert(res4.data.errors.some(e => e.field === 'dateFrom'), 'Should have error for dateFrom');
+  console.log('✔️  Caught invalid dateFrom format');
+
+  // Test case 5: Valid input should pass
+  const { req: req5, res: res5, next: next5, getNextCalled: next5Called } = createMocks({ 
+    maxResults: 50, 
+    timeRange: '1h',
+    fetchAll: true
+  });
+  middleware(req5, res5, next5);
+  
+  assert(next5Called(), 'Next should be called for valid input');
+  assert(req5.body.maxResults === 50, 'Valid input should be parsed and replace body');
+  assert(req5.body.timeRange === '1h', 'Valid enum should be parsed');
+  assert(req5.body.fetchAll === true, 'Valid boolean should be parsed');
+  console.log('✔️  Valid input passed successfully');
+
+  console.log('✅ All invalid-input tests passed!');
+  process.exit(0);
+};
+
+runTests();


### PR DESCRIPTION
## Overview
Resolves #18. The Gmail `/fetch` route was previously checking `req.query` for validation, but the controller expects parameters in `req.body`. This PR fixes the schema and applies it to the correct request source to prevent invalid payloads from bypassing expected limits.

## Key Changes
- **Schema Update**: Expanded `gmailFetchSchema` in `validation.js` to include missing body parameters (`dateFrom`, `dateTo`, `fetchAll`, and `timeRange`).
- **Route Fix**: Changed the validation middleware target on `/api/gmail/fetch` from `'query'` to `'body'`.
- **Security Enhancement**: Swapped middleware order to run `validate` *before* `authMiddleware`, saving server resources by rejecting malformed requests earlier.
- **Bug Fix**: Fixed a minor bug in the Zod validation middleware so `error.issues` are now correctly returned in the 400 Bad Request payload.

## Testing
- Added `backend/test-gmail-validation.js` to serve as an invalid-input test suite.
- Verified that requests with out-of-bounds `maxResults` (> 500), invalid enums, and malformed dates successfully trigger a `400 Bad Request`.
