### PR TITLE
 [Caching] Make cache keys deterministic across query order 

### DIFF
--- a/backend/middleware/cacheMiddleware.js
+++ b/backend/middleware/cacheMiddleware.js
@@ -51,9 +51,12 @@ function cacheMiddleware(options = {}) {
     } else {
       // Default: use userId + route path + query params
       const userId = req.mongoUserId || req.userId || 'anonymous';
-      const queryString = Object.keys(req.query).length > 0 
-        ? JSON.stringify(req.query) 
-        : '';
+   const queryString = Object.keys(req.query).length > 0 
+  ? JSON.stringify(Object.keys(req.query).sort().reduce((acc, key) => {
+      acc[key] = req.query[key];
+      return acc;
+    }, {}))
+  : '';
       cacheKey = `route:${userId}:${req.path}${queryString}`;
     }
 


### PR DESCRIPTION
Closes #26

## Changes
- Sorted query params before JSON.stringify
- Same params in different order now generate identical cache keys
- Improves cache hit rate and consistency