### PR TITLE
fix(cache): clean up expired entries before LRU eviction

### DIFF
--- a/ml-service/prediction_cache.py
+++ b/ml-service/prediction_cache.py
@@ -39,6 +39,18 @@ class PredictionCache:
     
     Automatically invalidates when model version changes.
     """
+    def _cleanup_expired(self) -> None:
+        """
+        Remove all expired entries from the cache.
+        """
+        current_time = time.time()
+        keys_to_delete = [
+            key for key, entry in self.cache.items()
+            if current_time - entry["cached_at"] > self.ttl_seconds
+        ]
+
+        for key in keys_to_delete:
+            del self.cache[key]
     
     def __init__(self, max_size: int = 10000, ttl_seconds: int = 3600):
         """
@@ -125,18 +137,15 @@ class PredictionCache:
     def set(self, text: str, model_version: str, result: Dict[str, Any]) -> None:
         """
         Store prediction result in cache.
-        
-        Args:
-            text: Email text content
-            model_version: Current model version
-            result: Prediction result dict to cache
         """
         cache_key = self._generate_cache_key(text, model_version)
-        
+
         with self.lock:
+        
+            self._cleanup_expired()
+
             # Check if we need to evict (LRU)
             if len(self.cache) >= self.max_size and cache_key not in self.cache:
-                # Remove oldest entry
                 self.cache.popitem(last=False)
                 self.evictions += 1
             


### PR DESCRIPTION
### Description
This PR fixes an issue in `prediction_cache.py` where expired cache entries were not removed before applying LRU eviction during `set()` operations.

### Problem

- Expired entries were only removed during `get()` calls. If expired entries were not accessed again, they remained in the cache and continued occupying space.
- During `set()`, eviction was performed based solely on LRU order, which could result in valid entries being evicted while expired entries remained.

### Closed Issue
Closes #64 

### Changes

- Added a `_cleanup_expired()` helper method to remove expired cache entries
- Invoked cleanup at the start of the set() method before eviction logic
- Ensured eviction operates only on valid (non-expired) entries

### Impact

- Prevents expired entries from occupying cache space
- Improves cache efficiency and hit rate
- Ensures correct interaction between TTL expiration and LRU eviction

### Notes

- > No changes to public API
- > No impact on existing functionality beyond improved correctness
- > Thread-safety preserved

### Checklist

- [x]  Code follows project guidelines
- [x]  Changes are minimal and focused
- [x]  No breaking changes introduced
- [x]  Tested locally