### PR TITLE
fix: correct status code fallback in error handler

### DIFF
--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -33,7 +33,7 @@ const errorHandler = (err, req, res, next) => {
 
   // Determine status code
   // Use error's statusCode if available, otherwise default to 500
-  const statusCode = err.statusCode || res.statusCode || 500;
+  const statusCode = err.statusCode || (res.statusCode !== 200? res.statusCode : 500);
 
   // Prepare error response (never include sensitive data)
   const errorResponse = {


### PR DESCRIPTION
### Description
The global error handler was using:
`const statusCode = err.statusCode || res.statusCode || 500;`

This could return incorrect HTTP 200 responses when `res.statusCode` was still at its default value (200), even during errors.

### Fix
Updated the fallback logic to ensure a proper error status code is returned:

```
const statusCode =
  err.statusCode || (res.statusCode !== 200 ? res.statusCode : 500);
```
### Closed Issue
Closes #70 

### Result
- Prevents accidental `200 OK `responses for errors
- Ensures correct HTTP status codes
- Improves API reliability and debugging

### Testing
- Verified that errors without explicit status now return 500
- Confirmed existing custom status codes still work correctly