### PR TITLE
fix(security): remove X-Cache-Key response header to prevent user ID leakage

### DIFF
--- a/backend/middleware/cacheMiddleware.js
+++ b/backend/middleware/cacheMiddleware.js
@@ -66,11 +66,10 @@ function cacheMiddleware(options = {}) {
     if (cachedResponse) {
       // Cache HIT - Return cached response
       console.log(`⚡ Cache HIT - Serving cached response for: ${req.path}`);
-      
-      // Add cache header
+
+      // Add cache header (but not the internal cache key for security)
       res.set('X-Cache', 'HIT');
-      res.set('X-Cache-Key', cacheKey);
-      
+
       return res.json(cachedResponse);
     }
 
@@ -95,10 +94,9 @@ function cacheMiddleware(options = {}) {
       if (shouldCacheResponse) {
         cache.set(cacheKey, body, ttl);
         console.log(`💾 Response cached for ${ttl}s: ${req.path}`);
-        
-        // Add cache header
+
+        // Add cache header (but not the internal cache key for security)
         res.set('X-Cache', 'MISS');
-        res.set('X-Cache-Key', cacheKey);
       } else {
         console.log(`⏭️  Response NOT cached (status: ${res.statusCode}): ${req.path}`);
         res.set('X-Cache', 'SKIP');


### PR DESCRIPTION
## Summary

Closes #79

The cache middleware was adding `X-Cache-Key` HTTP response headers containing the full internal cache key. Since cache keys embed user IDs (MongoDB ObjectId or Clerk user ID), this exposed sensitive user identification information to clients in HTTP responses.

## Vulnerability Details

**Impact**: User ID information disclosure
**Severity**: Medium (user IDs are semi-public but part of authorization context)

**Affected Lines**:
- cacheMiddleware.js line 72: `res.set('X-Cache-Key', cacheKey);` (cache HIT path)
- cacheMiddleware.js line 101: `res.set('X-Cache-Key', cacheKey);` (cache MISS path)

**Example Leaked Information**:
```
X-Cache-Key: route:user_2s1234567890abcdef:api/emails?page=1
```

From this header, attackers could:
- Enumerate valid user IDs across the application
- Link API requests to specific users
- Build user ID databases for targeted attacks

## Fix

Removed `X-Cache-Key` response headers while retaining the public `X-Cache` header for legitimate cache diagnostics:

**Before**:
```
X-Cache: HIT
X-Cache-Key: route:user_2s1234567890abcdef:api/emails?page=1
```

**After**:
```
X-Cache: HIT
```

The `X-Cache` header (HIT/MISS/SKIP) is retained for:
- Performance debugging by developers
- CDN cache status visibility
- No sensitive user information exposure

## Testing

- [ ] Cache HIT responses return X-Cache: HIT (no X-Cache-Key)
- [ ] Cache MISS responses return X-Cache: MISS (no X-Cache-Key)
- [ ] Cache SKIP responses return X-Cache: SKIP
- [ ] Application cache functionality works correctly
- [ ] No X-Cache-Key header appears in any response

## Program

This contribution is submitted under **NSoC'26** (Nexus Spring of Code 2026).

Please apply labels for NSoC'26 contribution tracking: `type:security`, `level:beginner`, `area:backend`

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>