### PR TITLE
fix(auth): use req.userId instead of req.user.id in deletion preferences routes

### DIFF
--- a/backend/routes/deletionRoutes.js
+++ b/backend/routes/deletionRoutes.js
@@ -11,7 +11,7 @@ const router = express.Router();
  */
 router.get('/preferences', authMiddleware, async (req, res) => {
   try {
-    const user = await User.findById(req.user.id);
+    const user = await User.findById(req.userId);
     
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
@@ -42,7 +42,7 @@ router.put('/preferences', authMiddleware, async (req, res) => {
     }
 
     const user = await User.findByIdAndUpdate(
-      req.user.id,
+      req.userId,
       {
         'autoDeletePreferences.enabled': enabled !== undefined ? enabled : false,
         'autoDeletePreferences.retentionDays': retentionDays || 30,


### PR DESCRIPTION
## Summary

Closes #78

The authMiddleware sets `req.userId` with the Clerk user ID from `sessionClaims.sub`, but deletionRoutes.js references `req.user.id` which was never initialized. This caused `TypeError: Cannot read properties of undefined (reading 'id')` when accessing `/api/deletion/preferences` endpoints.

## Root Cause

authMiddleware (line 73):
```javascript
req.userId = sessionClaims.sub;
```

deletionRoutes.js (lines 14, 45):
```javascript
// Used req.user.id instead of req.userId
const user = await User.findById(req.user.id);
```

## Fix

Changed all references from `req.user.id` to `req.userId` in deletion preferences routes:
- Line 14: GET /api/deletion/preferences - User lookup
- Line 45: PUT /api/deletion/preferences - User update

## Testing

- [ ] GET /api/deletion/preferences returns user's deletion preferences
- [ ] PUT /api/deletion/preferences updates preferences with valid retention days
- [ ] Invalid retention days (outside 7-90 range) return 400 error
- [ ] Requests without authentication return 401 error

## Program

This contribution is submitted under **NSoC'26** (Nexus Spring of Code 2026).

Please apply labels for NSoC'26 contribution tracking: `type:bug`, `level:beginner`, `area:backend`

Signed-off-by: Anshul Jain <anshul23102@iiitd.ac.in>