### PR TITLE
Remove unused y_pred_proba

### DIFF
--- a/ml-service/retrain.py
+++ b/ml-service/retrain.py
@@ -330,7 +330,6 @@ class ModelRetrainer:
             # Make predictions
             print("Making predictions on test set...")
             y_pred = self.model.predict(X_test_vectorized)
-            y_pred_proba = self.model.predict_proba(X_test_vectorized)
             
             # Calculate metrics
             accuracy = accuracy_score(self.y_test, y_pred)


### PR DESCRIPTION
This PR removed unused variable `y_pred_proba` under function evaluate_model() in retrain.py

closes #73 